### PR TITLE
Run script without create new container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ update-submodule: ## Update the submodule fetching from github
 
 update: ## Update the submodule and send it to container
 	git submodule update --init --remote --force
-	make down build install migrate generate-executions get-data-contracts generate-executions-contratos run
+	make down build install migrate run
 	
 migrate: ## Run the database migration
 	$(COMMAND) 'sleep 15; cd /opt/services/livro-aberto/src; pipenv run python manage.py migrate;'

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 .DEFAULT_GOAL := help
 
 COMMAND = docker-compose run --rm livro-aberto-djangoapp /bin/bash -c
+COMMAND_ON_RUNNING_CONTAINER = docker exec -i -t sme-livro-aberto-docker_livro-aberto-djangoapp_1 /bin/bash -c
+
 
 all: update-submodule setup build install first-migration generate-executions create-super-user run ## Setup and Install the Livro-Aberto APP using Docker.
 
@@ -60,7 +62,7 @@ get-data-contracts: ## Get the contract data from API SOF based on contrato_raw_
 	$(COMMAND) 'sleep 15; cd /opt/services/livro-aberto/src; pipenv run python manage.py runscript get_empenhos_for_contratos_from_sof_api;'
 
 generate-executions-contratos: ## Cruza os dados das duas tabelas e aplica o de-para conforme script generate_execucoes_contratos
-	$(COMMAND) 'sleep 15; cd /opt/services/livro-aberto/src; pipenv run python manage.py runscript generate_execucoes_contratos;'
+	$(COMMAND_ON_RUNNING_CONTAINER) 'sleep 15; cd /opt/services/livro-aberto/src; pipenv run python manage.py runscript generate_execucoes_contratos;'
 
 clean: ## Clean all the images, networks and containers unused - WARNING: THIS OPTION WILL REMOVE ALL UNUSED IMAGES, NETWORKS AND CONTAINERS.
 	docker system prune -a


### PR DESCRIPTION
Added instructions to make sure the script `generate_execucoes_contratos.py` will run on a existing container. 